### PR TITLE
Normalize the source file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.4]
+
+### Fixed
+
+- The path is relative to the test file. If the source file is already open vscode would open it another time using the unnormalized file path.
+
 ### Changed
 
 - Updated googletest links.

--- a/src/AbstractTestInfo.ts
+++ b/src/AbstractTestInfo.ts
@@ -1,5 +1,5 @@
+import * as path from 'path';
 import { TestEvent, TestInfo } from 'vscode-test-adapter-api';
-
 import { generateUniqueId } from './Util';
 import { SharedVariables } from './SharedVariables';
 
@@ -9,6 +9,7 @@ export abstract class AbstractTestInfo implements TestInfo {
   public readonly origLabel: string;
   public readonly description: string;
   public readonly tooltip: string;
+  public readonly file: string | undefined;
 
   public lastRunState: string | undefined = undefined;
   public lastRunMilisec: number | undefined = undefined;
@@ -19,7 +20,7 @@ export abstract class AbstractTestInfo implements TestInfo {
     public readonly testNameAsId: string,
     public readonly label: string,
     public readonly skipped: boolean,
-    public readonly file: string | undefined,
+    file: string | undefined,
     public readonly line: number | undefined,
     description: string | undefined,
     tooltip: string | undefined,
@@ -27,6 +28,7 @@ export abstract class AbstractTestInfo implements TestInfo {
     this.id = id ? id : generateUniqueId();
     this.origLabel = label;
     this.description = description ? description : '';
+    this.file = file ? path.normalize(file) : undefined;
     this.tooltip = 'Name: ' + testNameAsId + (tooltip ? '\n' + tooltip : '');
     if (line && line < 0) throw Error('line smaller than zero');
   }

--- a/src/Catch2TestSuiteInfo.ts
+++ b/src/Catch2TestSuiteInfo.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import { inspect, promisify } from 'util';
 import { TestEvent } from 'vscode-test-adapter-api';
-import * as path from 'path';
 import * as xml2js from 'xml2js';
 
 import { Catch2TestInfo } from './Catch2TestInfo';
@@ -112,7 +111,7 @@ export class Catch2TestSuiteInfo extends AbstractTestSuiteInfo {
           testNameAsId,
           description,
           tags,
-          path.normalize(filePath),
+          filePath,
           line - 1,
           index != -1 ? oldChildren[index].sections : undefined,
         ),

--- a/src/Catch2TestSuiteInfo.ts
+++ b/src/Catch2TestSuiteInfo.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { inspect, promisify } from 'util';
 import { TestEvent } from 'vscode-test-adapter-api';
+import * as path from 'path';
 import * as xml2js from 'xml2js';
 
 import { Catch2TestInfo } from './Catch2TestInfo';
@@ -111,7 +112,7 @@ export class Catch2TestSuiteInfo extends AbstractTestSuiteInfo {
           testNameAsId,
           description,
           tags,
-          filePath,
+          path.normalize(filePath),
           line - 1,
           index != -1 ? oldChildren[index].sections : undefined,
         ),


### PR DESCRIPTION
The path is relative to the test file. If the source file is already open vscode would open it another time using the unnormalized file path.