### PR TITLE
Add _findFilePath call to resolve relative paths.

### DIFF
--- a/src/framework/DOCTestSuiteInfo.ts
+++ b/src/framework/DOCTestSuiteInfo.ts
@@ -41,7 +41,7 @@ export class DOCTestSuiteInfo extends AbstractTestSuiteInfo {
       const testCase = res.doctest.TestCase[i].$;
 
       const testNameAsId = testCase.name;
-      const filePath: string | undefined = testCase.filename;
+      const filePath: string | undefined = testCase.filename ? this._findFilePath(testCase.filename) : undefined;
       const line: number | undefined = testCase.line !== undefined ? Number(testCase.line) - 1 : undefined;
       const skipped: boolean | undefined = testCase.skipped !== undefined ? testCase.skipped === 'true' : undefined;
       const suite: string | undefined = testCase.testsuite !== undefined ? testCase.testsuite : undefined;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix doctest source location when using relative paths.

**Which issue(s) this PR fixes**:

#169 

**Special notes for your reviewer**:

I've tested this on my machine. Catch2 and GTest already do this so I think it should be OK but I have 0 experience with TS.
