### PR TITLE
Make sure absolute patterns are not mistakenly consider as relative to workspace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [3.1.2]
+
+- Absolute patterns in Windows can now point to a different volume than the workspace folder.
+
 ## [3.1.1] - 2020-05-14
 
 ### Added

--- a/src/ExecutableConfig.ts
+++ b/src/ExecutableConfig.ts
@@ -294,7 +294,7 @@ export class ExecutableConfig implements vscode.Disposable {
     return {
       isAbsolute,
       absPattern,
-      isPartOfWs: !relativeToWs.startsWith('..'),
+      isPartOfWs: relativeToWs !== absPattern && !relativeToWs.startsWith('..'),
       relativeToWsPosix: relativeToWs.replace(/\\/g, '/'),
     };
   }


### PR DESCRIPTION
In Windows patterns pointing at a different volume than the workspace (e.g. workspace in `C:\path\to\workspace` and pattern `X:\**\*_test.exe`) were mistakenly considered as relative to the workspace, making discovery fail.

This was happening because `pathlib.relative('C:\path\to\workspace', 'X:\**\*_test.exe')` returns `'X:\**\*_test.exe'`, which doesn't start with `'..'`.