### PR TITLE
Feature/catch2 v3 description deprecation

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,5 +5,6 @@ module.exports = {
 	printWidth: 120,
 	tabWidth: 2,
 	useTabs: false,
-	arrowParens: 'avoid'
+	arrowParens: 'avoid',
+	endOfLine: 'auto'
 };

--- a/src/framework/Catch2Runnable.ts
+++ b/src/framework/Catch2Runnable.ts
@@ -117,8 +117,13 @@ export class Catch2Runnable extends AbstractRunnable {
         }
       }
 
-      let description = lines[i++].substr(4);
-      if (description.startsWith('(NO DESCRIPTION)')) description = '';
+      let description = '';
+      // Catch2 v3 deprecates descriptions
+      if (i < lines.length && lines[i].startsWith('   ') && !lines[i].startsWith('      [')) {
+        description = lines[i].substr(4);
+        if (description.startsWith('(NO DESCRIPTION)')) description = '';
+        ++i;
+      }
 
       const tags: string[] = [];
       if (i < lines.length && lines[i].startsWith('      [')) {

--- a/test/Catch2Framework.test.ts
+++ b/test/Catch2Framework.test.ts
@@ -234,4 +234,74 @@ describe(path.basename(__filename), function () {
     assert.strictEqual(suite1.label, 'execPath1.exe');
     assert.equal(suite1.children.length, 5, inspect([testListOutput, adapter.testLoadsEvents]));
   });
+
+  specify('tests without description line', async function () {
+    this.slow(500);
+    await settings.updateConfig('test.executables', example1.suite1.execPath);
+
+    adapter = new TestAdapter();
+
+    const testListOutput = [
+      'Matching test cases:',
+      '  first',
+      '    /mnt/c/Users/a.cpp:12',
+      '      [a]',
+      '  second',
+      '    /mnt/c/Users/b.cpp:42',
+      '      [b]',
+      '2 matching test cases',
+    ];
+
+    const withArgs = imitation.spawnStub.withArgs(
+      example1.suite1.execPath,
+      example1.suite1.outputs[1][0],
+      sinon.match.any,
+    );
+    withArgs.onCall(withArgs.callCount).returns(new ChildProcessStub(testListOutput.join(EOL)));
+
+    await adapter.load();
+
+    assert.equal(adapter.root.children.length, 1);
+
+    const suite1 = adapter.group1;
+    assert.equal(suite1.children.length, 2, inspect([testListOutput, adapter.testLoadsEvents]));
+
+    assert.strictEqual(suite1.label, 'execPath1.exe');
+    assert.strictEqual(suite1.children[0].label, 'first');
+    assert.strictEqual(suite1.children[1].label, 'second');
+  });
+
+  specify('tests without description or tags line', async function () {
+    this.slow(500);
+    await settings.updateConfig('test.executables', example1.suite1.execPath);
+
+    adapter = new TestAdapter();
+
+    const testListOutput = [
+      'Matching test cases:',
+      '  first',
+      '    /mnt/c/Users/a.cpp:12',
+      '  second',
+      '    /mnt/c/Users/b.cpp:42',
+      '2 matching test cases',
+    ];
+
+    const withArgs = imitation.spawnStub.withArgs(
+      example1.suite1.execPath,
+      example1.suite1.outputs[1][0],
+      sinon.match.any,
+    );
+    withArgs.onCall(withArgs.callCount).returns(new ChildProcessStub(testListOutput.join(EOL)));
+
+    await adapter.load();
+
+    assert.equal(adapter.root.children.length, 1);
+
+    const suite1 = adapter.group1;
+    assert.equal(suite1.children.length, 2, inspect([testListOutput, adapter.testLoadsEvents]));
+
+    assert.strictEqual(suite1.label, 'execPath1.exe');
+    assert.strictEqual(suite1.children[0].label, 'first');
+    assert.strictEqual(suite1.children[1].label, 'second');
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**: 

Accounts for the Catch2 v3 deprecation of the TEST_CASE descriptions feature

**Which issue(s) this PR fixes**:

Fixes #202

**Special notes for your reviewer**:

Sadly I had troubles making _all_ tests run, `npm test` was only executing `Configurations.test.ts`. So I've installed the extension from the `vsix` and confirmed that it fixed the problem on the working project.
