### PR TITLE
Fix issue 245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [3.6.16] - 2020-12-12
+
+### Fixed
+
+- an issue where Catch2 v3 tests with tags were parsed incorrectly
+
 ## [3.6.15] - 2020-12-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [3.6.16] - 2020-12-12
-
 ### Fixed
 
 - an issue where Catch2 v3 tests with tags were parsed incorrectly

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-catch2-test-adapter",
-  "version": "3.6.14",
+  "version": "3.6.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/icon.png",
   "author": "Mate Pek",
   "publisher": "matepek",
-  "version": "3.6.15",
+  "version": "3.6.16",
   "license": "MIT",
   "homepage": "https://github.com/matepek/vscode-catch2-test-adapter",
   "repository": {

--- a/src/framework/Catch2Runnable.ts
+++ b/src/framework/Catch2Runnable.ts
@@ -197,7 +197,6 @@ export class Catch2Runnable extends AbstractRunnable {
       if (testCase.Tags[0]) {
         const matches = testCase.Tags[0].match(/\[[^\[\]]+\]/g);
         if (matches) matches.forEach((t: string) => tags.push(t.substring(1, t.length - 1)));
-        ++i;
       }
 
       reloadResult.add(

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -48,7 +48,8 @@ add_catch2test_with_main(suite5 "suite5.cpp")
 
 include("Catch2v3Test.cmake")
 
-add_catch2v3test_with_main(catch2v3_test1 "catch2v3_test1.cpp")
+add_catch2v3test_with_main(catch2v3_test1 "catch2v3_test1.cpp;catch2_bdd_tests/a.test.cpp;catch2_bdd_tests/b.test.cpp;catch2_bdd_tests/c.test.cpp")
+
 
 #
 

--- a/test/cpp/Catch2v3Test.cmake
+++ b/test/cpp/Catch2v3Test.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(catch2v3test
                      GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                     GIT_TAG v3.0.0-preview2)
+                     GIT_TAG v3.0.0-preview3)
 
 FetchContent_GetProperties(catch2v3test)
 if(NOT catch2v3test_POPULATED)
@@ -19,8 +19,8 @@ add_library(ThirdParty.Catch2v3WithMain ALIAS Catch2WithMain)
 
 #
 
-function(add_catch2v3test_with_main target cpp_file)
-  add_executable(${target} "${cpp_file}")
+function(add_catch2v3test_with_main target cpp_files)
+  add_executable(${target} ${cpp_files})
   target_link_libraries(${target} PUBLIC ThirdParty.Catch2v3WithMain)
   target_compile_definitions(${target} PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
 endfunction()

--- a/test/cpp/catch2_bdd_tests/a.test.cpp
+++ b/test/cpp/catch2_bdd_tests/a.test.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("some scenario", "[.][integration]") {
+    GIVEN("a widget, a gadget, a whoozit, a whatzit, and a thingamajig") {
+        WHEN("foo is barred") {
+            THEN("bif is bazzed") {
+                REQUIRE(true);
+            }
+        }
+    }
+}

--- a/test/cpp/catch2_bdd_tests/b.test.cpp
+++ b/test/cpp/catch2_bdd_tests/b.test.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("some scenario +", "[.][integration]") {
+    GIVEN("a widget, a gadget, a whoozit, a whatzit, and a thingamajig") {
+        WHEN("foo is barred") {
+            THEN("bif is bazzed") {
+                REQUIRE(true);
+            }
+        }
+    }
+}

--- a/test/cpp/catch2_bdd_tests/c.test.cpp
+++ b/test/cpp/catch2_bdd_tests/c.test.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("completely different", "[.][unit]") {
+    GIVEN(":a widget, a gadget, a whoozit, a whatzit, and a thingamajig") {
+        WHEN(":foo is barred") {
+            THEN(":bif is bazzed") {
+                REQUIRE(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!  Here are some tips for you:
  Please read: https://github.com/matepek/vscode-catch2-test-adapter/blob/master/CONTRIBUTING.md

  Checklist:
  - Are the tests are running? (`npm test`)
  - Is the `CHANGELOG.md` was updated?
-->

**What this PR does / why we need it**:
In Catch2 v3 tests with tags, the parser was accidentally skipping the next element (test case), causing some tests to be missed.

**Which issue(s) this PR fixes**:
Fixes #245 


**Special notes for your reviewer**:
Some additional tests were added in the cpp sample project to allow verification in integration test mode.

(updated to version 3.6.16 -- ready for release)