### PR TITLE
Fix splitting of tests into subsets

### DIFF
--- a/src/AbstractRunnable.ts
+++ b/src/AbstractRunnable.ts
@@ -476,6 +476,7 @@ export abstract class AbstractRunnable {
       if (charCount + test.testNameAsId.length >= limit) {
         lastSet = [];
         subsets.push(lastSet);
+        charCount = 0;
       }
       lastSet.push(test);
       charCount += test.testNameAsId.length;


### PR DESCRIPTION
When splitting the test list for a bucket into small enough subsets, it would
create the first subset correctly (with as many tests as will fit in under 30000
characters), but all remaining subsets for that bucket would contain only a
single test.