### PR TITLE
Support very latest version of Catch v3

### DIFF
--- a/src/ExecutableFactory.ts
+++ b/src/ExecutableFactory.ts
@@ -94,7 +94,7 @@ const frameworkDatas: Record<
 > = {
   catch2: {
     priority: 10,
-    regex: /Catch v(\d+)\.(\d+)\.(\d+)\s?/,
+    regex: /Catch2? v(\d+)\.(\d+)\.(\d+)\s?/,
     create: (sharedVarOfExec: SharedVarOfExec, match: RegExpMatchArray) =>
       new Catch2Executable(sharedVarOfExec, parseVersion123(match)),
   },


### PR DESCRIPTION
Update the regex for parsing the help string of Catch test runners
to support the latest version of Catch2 v3.

It started saying "Catch2 v..." instead of "Catch v..." recently, see
https://github.com/catchorg/Catch2/commit/dc86d51af2a7.
