### PR TITLE
Make discovery.runtimeLimit option take effect immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- changing the `testMate.cpp.discovery.runtimeLimit` option used to take effect only after reloading the window; now it takes effect immediately
+
 ## [4.0.25] - 2022-02-05
 
 ### Fixed

--- a/src/WorkspaceManager.ts
+++ b/src/WorkspaceManager.ts
@@ -152,7 +152,7 @@ export class WorkspaceManager implements vscode.Disposable {
             this._shared.setExecRunningTimeout(config.getExecRunningTimeout());
           }
           if (affectsAny('discovery.runtimeLimit')) {
-            this._shared.setExecRunningTimeout(config.getExecParsingTimeout());
+            this._shared.setExecParsingTimeout(config.getExecParsingTimeout());
           }
           if (affectsAny('debug.noThrow')) {
             this._shared.isNoThrow = config.getDefaultNoThrow();

--- a/src/WorkspaceShared.ts
+++ b/src/WorkspaceShared.ts
@@ -55,6 +55,10 @@ export class WorkspaceShared {
     this._execRunningTimeoutChangeEmitter.fire();
   }
 
+  setExecParsingTimeout(value: number): void {
+    this.execParsingTimeout = value;
+  }
+
   readonly onDidChangeExecRunningTimeout = this._execRunningTimeoutChangeEmitter.event;
 }
 


### PR DESCRIPTION
Fixes #331.