### PR TITLE
docs: fix grammar error `uses` -> `used`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The previous version (v3.x.y) of the extension is published as [C++ TestMate Leg
 in case this is too buggy or you cannot wait for some old feature.
 
 - New testing API integration has just happened with a tons of improvements.
-  - Streaming the test run: Don't have to wait for the result to see the progress (in case you test uses `std::cout`)
+  - Streaming the test run: Don't have to wait for the result to see the progress (in case you test used `std::cout`)
   - Catch Section and DOCTest SubCase support (limited but still sometings)
 - Runs executables parallel (_testMate.cpp.test.parallelExecutionLimit_).
 - Sorts tests and suites (_testExplorer.sort_).


### PR DESCRIPTION
The PR fixes a grammar error in the docs which has been mentioned above.

[Line 23](https://github.com/matepek/vscode-catch2-test-adapter/blob/9f5bdba46ff9e7d673d951b46d216e378fd6e8f3/README.md?plain=1#L23)