### PR TITLE
Filter out environment variables with newlines

### DIFF
--- a/src/WorkspaceManager.ts
+++ b/src/WorkspaceManager.ts
@@ -460,7 +460,9 @@ export class WorkspaceManager implements vscode.Disposable {
       //   TestAdapter._debugMetricSent = true;
       // }
 
-      const envVars = Object.assign({}, process.env, executable.shared.options.env);
+      const envVarsRaw = Object.assign({}, process.env, executable.shared.options.env);
+      const envVarsEntries = Object.entries(envVarsRaw).filter(item => !item[1]?.includes("\n"));
+      const envVars = Object.fromEntries(envVarsEntries);
 
       {
         const setEnvKey = 'testMate.cpp.debug.setEnv';


### PR DESCRIPTION
**What this PR does / why we need it**: Immediately prior to invoking the VS Code debugger, filter out environment variables that contain newlines. Failure to do so leads to the debugger crashing.

**Which issue(s) this PR fixes**: Fixes #364 

**Special notes for your reviewer**: I'm not much of a typescript dev, so I don't claim that this is an idiomatic implementation. Happy to change/add tests/etc.