### PR TITLE
Fix running custom tasks by removing `name` setter hack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-catch2-test-adapter",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-catch2-test-adapter",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "@types/htmlparser2": "^3.10.3",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "webpack-cli": "^4.10.0"
   },
   "engines": {
-    "vscode": "1.65.0"
+    "vscode": "^1.65.0"
   },
   "activationEvents": [
     "onStartupFinished"

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -60,6 +60,14 @@ export function concat(left: string, right: string, sep = ''): string {
 }
 
 export class Version {
+  static from(value: string): Version | undefined {
+    const match = value.match(/^(\d+)(?:\.(\d+)(?:\.(\d+))?)?$/);
+    if (!match) return undefined;
+
+    const [, major, minor, patch] = match;
+    return new Version(Number(major), minor ? Number(minor) : undefined, patch ? Number(patch) : undefined);
+  }
+
   constructor(readonly major: number, private readonly _minor?: number, private readonly _patch?: number) {}
 
   get minor(): number {

--- a/src/WorkspaceManager.ts
+++ b/src/WorkspaceManager.ts
@@ -12,7 +12,7 @@ import { sep as osPathSeparator } from 'path';
 import { TaskQueue } from './util/TaskQueue';
 import { AbstractExecutable, TestsToRun } from './framework/AbstractExecutable';
 import { ConfigOfExecGroup } from './ConfigOfExecGroup';
-import { generateId } from './Util';
+import { generateId, Version } from './Util';
 import { AbstractTest } from './framework/AbstractTest';
 import { TestItemManager } from './TestItemManager';
 import { ProgressReporter } from './util/ProgressReporter';
@@ -87,10 +87,13 @@ export class WorkspaceManager implements vscode.Disposable {
         }
 
         const resolvedTask = await resolveVariablesAsync(found, varToValue);
-        // Task.name setter needs to be triggered in order for the task to clear its __id field
-        // (https://github.com/microsoft/vscode/blob/ba33738bb3db01e37e3addcdf776c5a68d64671c/src/vs/workbench/api/common/extHostTypes.ts#L1976),
-        // otherwise task execution fails with "Task not found".
-        resolvedTask.name += '';
+
+        if (Version.from(vscode.version)?.smaller(new Version(1, 72))) {
+          // Task.name setter needs to be triggered in order for the task to clear its __id field
+          // (https://github.com/microsoft/vscode/blob/ba33738bb3db01e37e3addcdf776c5a68d64671c/src/vs/workbench/api/common/extHostTypes.ts#L1976),
+          // otherwise task execution fails with "Task not found".
+          resolvedTask.name += '';
+        }
 
         if (cancellationToken.isCancellationRequested) return;
 


### PR DESCRIPTION
This may have been needed on older version of VS Code, but this setter would reset the `definition` of a task such that custom execution tasks (such as those provided by the CMake Tools extension) would fail with: `"undefined" is not a recognized command.`

I tested with CMake Tools and other custom tasks to ensure tasks would now run correctly for me without this error.