### PR TITLE
Add link to pre configured glob pattern in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ in case this is too buggy or you cannot wait for some old feature.
 ### More features
 
 - One executable can be run parallel with distinct set of subtests to boost runtime.
-- Finds and recognises the executables by a given [glob pattern](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options). ([More](#catch2TestExplorer_executables))
+- Finds and recognises the executables by a given [glob pattern](https://github.com/matepek/vscode-catch2-test-adapter/blob/master/documents/configuration/test.advancedExecutables.md).
 - Automatically runs executables if it is modified ("_..._" -> "_Enable autorun_") or if a dependency is modified (`dependsOn`)
 - Grouping can be fully customized. ([Details](https://github.com/matepek/vscode-catch2-test-adapter/blob/master/documents/configuration/test.advancedExecutables.md#testgrouping))
 - and many more.. Ask on [gitter](https://gitter.im/CppTestMate/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge).
@@ -48,8 +48,7 @@ in case this is too buggy or you cannot wait for some old feature.
 [test.advancedexecutables]: https://github.com/matepek/vscode-catch2-test-adapter/blob/master/documents/configuration/test.advancedExecutables.md
 [debug.configtemplate]: https://github.com/matepek/vscode-catch2-test-adapter/blob/master/documents/configuration/debug.configTemplate.md
 
-The extension is \*_pre-configured_ and it should find executables inside the working directory which match the following [_glob pattern_](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options):
-Not good enough for you?!: Edit your `.vscode/`[settings.json] file according to the [test.advancedExecutables]!
+The extension is \*_pre-configured_ and it should find executables inside the working directory which match the [_glob pattern_](https://github.com/matepek/vscode-catch2-test-adapter/blob/master/documents/configuration/test.advancedExecutables.md). Not good enough for you?!: Edit your `.vscode/`[settings.json] file according to the [test.advancedExecutables]!
 
 | `testMate.cpp.___`                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
**What this PR does / why we need it**:
README is mentioning a glob pattern mulitple times, but never actually shows/links it.

**Which issue(s) this PR fixes**:
I just tried to get this running and was unable to do so from the informtion provided within README.

**Special notes for your reviewer**:
I feel mentioning the definition of a "glob pattern" is just too many links here. We do not want to link "what is *a* glob pattern" and "what is *the* glob pattern".