### PR TITLE
More efficient build process checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - improved gtest output parser
+- `waitForBuildProcess` now uses `ps-list` to be faster on Windows ([related](https://github.com/matepek/vscode-catch2-test-adapter/issues/488))
 
 ### Deprecated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chokidar": "^5.0.0",
         "dotenv": "^17.4.1",
         "find-process": "^2.1.1",
+        "ps-list": "^8.1.1",
         "tslib": "^2.8.1",
         "vscode-test-adapter-util": "^0.7.1"
       },
@@ -24,6 +25,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",
+        "@types/ps-list": "^6.0.0",
         "@types/request-promise": "4.1.51",
         "@types/sinon": "^21.0.1",
         "@types/source-map-support": "^0.5.10",
@@ -7033,6 +7035,18 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ps-list": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
+      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,10 +1046,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+    "node_modules/@types/ps-list": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ps-list/-/ps-list-6.0.0.tgz",
+      "integrity": "sha512-FuoItqYGkFXGrrlTraXZ5d4b7bNc9MBRWLAusHZWI9j8+LFoF+z938cizoetAQ3ui6K0BomAw5sFQYS2NVbV3Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chokidar": "^5.0.0",
         "dotenv": "^17.4.1",
         "find-process": "^2.1.1",
-        "ps-list": "^8.1.1",
+        "ps-list": "^9.0.0",
         "tslib": "^2.8.1",
         "vscode-test-adapter-util": "^0.7.1"
       },
@@ -1038,6 +1038,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -7037,12 +7044,12 @@
       "license": "MIT"
     },
     "node_modules/ps-list": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
-      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-9.0.0.tgz",
+      "integrity": "sha512-lxMEoIL/BQlk2KunFzxwUPwMvjFH7x7cmvzSLsSHpyMXl9FFfLUlfKrYwFc4wx/ZaIxxuXC4n8rjQ1CX/tkXVQ==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chokidar": "^5.0.0",
     "dotenv": "^17.4.1",
     "find-process": "^2.1.1",
+    "ps-list": "^8.1.1",
     "tslib": "^2.8.1",
     "vscode-test-adapter-util": "^0.7.1"
   },
@@ -75,6 +76,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
+    "@types/ps-list": "^6.0.0",
     "@types/request-promise": "4.1.51",
     "@types/sinon": "^21.0.1",
     "@types/source-map-support": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chokidar": "^5.0.0",
     "dotenv": "^17.4.1",
     "find-process": "^2.1.1",
-    "ps-list": "^8.1.1",
+    "ps-list": "^9.0.0",
     "tslib": "^2.8.1",
     "vscode-test-adapter-util": "^0.7.1"
   },

--- a/src/WorkspaceShared.ts
+++ b/src/WorkspaceShared.ts
@@ -2,7 +2,7 @@ import { Logger } from './Logger';
 import * as vscode from 'vscode';
 import { TaskPool } from './util/TaskPool';
 import { ResolveRuleAsync } from './util/ResolveRule';
-import { BuildProcessChecker } from './util/BuildProcessChecker';
+import { BuildProcessChecker, FindProcessChecker } from './util/BuildProcessChecker';
 import { CancellationToken } from './Util';
 import { TestItemManager } from './TestItemManager';
 import { AbstractExecutable } from './framework/AbstractExecutable';
@@ -34,7 +34,7 @@ export class WorkspaceShared {
     public stderrDecorator: boolean,
   ) {
     this.taskPool = new TaskPool(workerMaxNumber);
-    this.buildProcessChecker = new BuildProcessChecker(log);
+    this.buildProcessChecker = new FindProcessChecker(log);
   }
 
   readonly taskPool: TaskPool;

--- a/src/WorkspaceShared.ts
+++ b/src/WorkspaceShared.ts
@@ -2,7 +2,7 @@ import { Logger } from './Logger';
 import * as vscode from 'vscode';
 import { TaskPool } from './util/TaskPool';
 import { ResolveRuleAsync } from './util/ResolveRule';
-import { BuildProcessChecker, FindProcessChecker } from './util/BuildProcessChecker';
+import { BuildProcessChecker, FindProcessChecker, PSListProcessChecker } from './util/BuildProcessChecker';
 import { CancellationToken } from './Util';
 import { TestItemManager } from './TestItemManager';
 import { AbstractExecutable } from './framework/AbstractExecutable';
@@ -34,7 +34,12 @@ export class WorkspaceShared {
     public stderrDecorator: boolean,
   ) {
     this.taskPool = new TaskPool(workerMaxNumber);
-    this.buildProcessChecker = new FindProcessChecker(log);
+
+    // https://www.npmjs.com/package/ps-list : "Works on macOS, Linux, and Windows. Windows ARM64 is not supported yet."
+    this.buildProcessChecker =
+      process.platform === 'win32' && process.arch == 'arm64'
+        ? new FindProcessChecker(log)
+        : new PSListProcessChecker(log);
   }
 
   readonly taskPool: TaskPool;

--- a/src/util/BuildProcessChecker.ts
+++ b/src/util/BuildProcessChecker.ts
@@ -1,5 +1,7 @@
+/// <reference types="node" />
 import { Logger } from '../Logger';
 import find from 'find-process';
+import psList from 'ps-list';
 
 ///
 
@@ -60,23 +62,25 @@ export class BuildProcessChecker {
 
   private async _refresh(pattern: RegExp): Promise<void> {
     try {
-      const processes = await find('name', pattern);
+      const allProcesses = await psList();
+      const processes = allProcesses.filter((proc: { name: string }) => pattern.test(proc.name));
 
       this._lastChecked = Date.now();
 
       if (processes.length > 0) {
         this._log.info(
-          'Found running build related processes: ' + processes.map(x => JSON.stringify(x, undefined, 0)).join(', '),
+          'Found running build related processes: ' +
+            processes.map((x: { name: string }) => JSON.stringify(x, undefined, 0)).join(', '),
         );
       } else {
         this._log.info('Not found running build related process');
         this._finishedResolver();
-        clearInterval(this._timerId!);
+        if (this._timerId) clearInterval(this._timerId);
         this._timerId = undefined;
       }
     } catch (reason) {
       this._log.exceptionS(reason);
-      clearInterval(this._timerId!);
+      if (this._timerId) clearInterval(this._timerId);
       this._timerId = undefined;
       this._finishedResolver();
     }

--- a/src/util/BuildProcessChecker.ts
+++ b/src/util/BuildProcessChecker.ts
@@ -1,24 +1,30 @@
-/// <reference types="node" />
 import { Logger } from '../Logger';
 import find from 'find-process';
 import psList from 'ps-list';
 
 ///
 
-// not so nice, init in rootsuite in the future
-export class BuildProcessChecker {
+export interface BuildProcessChecker {
+  dispose(): void;
+  resolveAtFinish(pattern: string | boolean | undefined): Promise<void>;
+}
+
+///
+
+const _checkIntervalMillis = 2000;
+// https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers
+const _defaultPattern =
+  /(^|[/\\])(bazel|cmake|make|ninja|cl|c\+\+|ld|clang|clang\+\+|gcc|g\+\+|link|icc|armcc|armclang)(-[^/\\]+)?(\.exe)?$/;
+
+///
+
+export class FindProcessChecker implements BuildProcessChecker {
   constructor(private readonly _log: Logger) {}
 
-  private readonly _checkIntervalMillis = 2000;
-  // https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers
-  private readonly _defaultPattern =
-    /(^|[/\\])(bazel|cmake|make|ninja|cl|c\+\+|ld|clang|clang\+\+|gcc|g\+\+|link|icc|armcc|armclang)(-[^/\\]+)?(\.exe)?$/;
   private _lastChecked = 0;
   private _finishedP = Promise.resolve();
   private _finishedResolver = (): void => {};
-  private _timerId: NodeJS.Timeout | undefined = undefined;
-  private _psListInFlight = false;
-  private _pendingRefresh = false;
+  private _timerId: NodeJS.Timeout | undefined = undefined; // number if have running build process
 
   dispose(): void {
     if (this._timerId) clearInterval(this._timerId);
@@ -56,47 +62,119 @@ export class BuildProcessChecker {
       patternToUse = this._defaultPattern;
     }
     this._log.info('Checking running build related processes', patternToUse);
-    this._timerId = setInterval(() => this._refresh(patternToUse), this._checkIntervalMillis);
+    this._timerId = global.setInterval(this._refresh.bind(this, patternToUse), _checkIntervalMillis);
     this._refresh(patternToUse);
 
     return this._finishedP;
   }
 
   private async _refresh(pattern: RegExp): Promise<void> {
-    if (this._psListInFlight) {
-      this._pendingRefresh = true;
-      return;
-    }
-    this._psListInFlight = true;
     try {
-      const allProcesses = await psList();
-      const processes = allProcesses.filter((proc: { name: string }) => pattern.test(proc.name));
+      // wrong type definition for find habdles RegExp: https://github.com/yibn2008/find-process/compare/1.4.11...2.0.0#diff-81b33228621820bded04ffbd7d49375fc742662fde6b7111ddb10457ceef7ae9R11
+      const processes = await find('name', pattern as unknown as string);
 
       this._lastChecked = Date.now();
 
       if (processes.length > 0) {
         this._log.info(
-          'Found running build related processes: ' +
-            processes.map((x: { name: string }) => JSON.stringify(x, undefined, 0)).join(', '),
+          'Found running build related processes: ' + processes.map(x => JSON.stringify(x, undefined, 0)).join(', '),
         );
       } else {
         this._log.info('Not found running build related process');
         this._finishedResolver();
-        if (this._timerId) clearInterval(this._timerId);
+        clearInterval(this._timerId!);
         this._timerId = undefined;
       }
     } catch (reason) {
       this._log.exceptionS(reason);
-      if (this._timerId) clearInterval(this._timerId);
+      clearInterval(this._timerId!);
       this._timerId = undefined;
       this._finishedResolver();
-    } finally {
-      this._psListInFlight = false;
-      if (this._pendingRefresh) {
-        this._pendingRefresh = false;
-        // Immediately retry
-        this._refresh(pattern);
-      }
     }
   }
 }
+
+///
+
+// export class PSListProcessChecker implements BuildProcessChecker {
+//   constructor(private readonly _log: Logger) {}
+
+//   private readonly _checkIntervalMillis = 2000;
+//   // https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers
+//   private readonly _defaultPattern =
+//     /(^|[/\\])(bazel|cmake|make|ninja|cl|c\+\+|ld|clang|clang\+\+|gcc|g\+\+|link|icc|armcc|armclang)(-[^/\\]+)?(\.exe)?$/;
+//   private _lastChecked = 0;
+//   private _finishedP = Promise.resolve();
+//   private _finishedResolver = (): void => {};
+//   private _timerId: NodeJS.Timeout | undefined = undefined;
+//   private _psListInFlight = false;
+//   private _pendingRefresh = false;
+
+//   dispose(): void {
+//     if (this._timerId) clearInterval(this._timerId);
+//     this._finishedResolver();
+//   }
+
+//   resolveAtFinish(pattern: string | boolean | undefined): Promise<void> {
+//     if (pattern === false) return Promise.resolve();
+
+//     if (this._timerId !== undefined) {
+//       return this._finishedP;
+//     }
+
+//     const elapsed = Date.now() - this._lastChecked;
+
+//     if (elapsed < 300) {
+//       return Promise.resolve();
+//     }
+
+//     this._finishedP = new Promise(r => {
+//       this._finishedResolver = r;
+//     });
+
+//     const patternToUse = typeof pattern == 'string' ? RegExp(pattern) : this._defaultPattern;
+//     this._log.info('Checking running build related processes', patternToUse);
+//     this._timerId = setInterval(() => this._refresh(patternToUse), this._checkIntervalMillis);
+//     this._refresh(patternToUse);
+
+//     return this._finishedP;
+//   }
+
+//   private async _refresh(pattern: RegExp): Promise<void> {
+//     if (this._psListInFlight) {
+//       this._pendingRefresh = true;
+//       return;
+//     }
+//     this._psListInFlight = true;
+//     try {
+//       const allProcesses = await psList();
+//       const processes = allProcesses.filter((proc: { name: string }) => pattern.test(proc.name));
+
+//       this._lastChecked = Date.now();
+
+//       if (processes.length > 0) {
+//         this._log.info(
+//           'Found running build related processes: ' +
+//             processes.map((x: { name: string }) => JSON.stringify(x, undefined, 0)).join(', '),
+//         );
+//       } else {
+//         this._log.info('Not found running build related process');
+//         this._finishedResolver();
+//         if (this._timerId) clearInterval(this._timerId);
+//         this._timerId = undefined;
+//       }
+//     } catch (reason) {
+//       this._log.exceptionS(reason);
+//       if (this._timerId) clearInterval(this._timerId);
+//       this._timerId = undefined;
+//       this._finishedResolver();
+//     } finally {
+//       this._psListInFlight = false;
+//       if (this._pendingRefresh) {
+//         this._pendingRefresh = false;
+//         // Immediately retry
+//         this._refresh(pattern);
+//       }
+//     }
+//   }
+// }

--- a/src/util/BuildProcessChecker.ts
+++ b/src/util/BuildProcessChecker.ts
@@ -59,7 +59,7 @@ export abstract class BuildProcessCheckerBase {
         this._patternToUseCache = { pattern, patternToUse };
       }
     } else {
-      patternToUse = this._defaultPattern;
+      patternToUse = _defaultPattern;
     }
     this._log.info('Checking running build related processes', patternToUse);
     this._timerId = global.setInterval(this._refresh.bind(this, patternToUse), _checkIntervalMillis);

--- a/src/util/BuildProcessChecker.ts
+++ b/src/util/BuildProcessChecker.ts
@@ -16,7 +16,9 @@ export class BuildProcessChecker {
   private _lastChecked = 0;
   private _finishedP = Promise.resolve();
   private _finishedResolver = (): void => {};
-  private _timerId: NodeJS.Timeout | undefined = undefined; // number if have running build process
+  private _timerId: NodeJS.Timeout | undefined = undefined;
+  private _psListInFlight = false;
+  private _pendingRefresh = false;
 
   dispose(): void {
     if (this._timerId) clearInterval(this._timerId);
@@ -54,13 +56,18 @@ export class BuildProcessChecker {
       patternToUse = this._defaultPattern;
     }
     this._log.info('Checking running build related processes', patternToUse);
-    this._timerId = global.setInterval(this._refresh.bind(this, patternToUse), this._checkIntervalMillis);
+    this._timerId = setInterval(() => this._refresh(patternToUse), this._checkIntervalMillis);
     this._refresh(patternToUse);
 
     return this._finishedP;
   }
 
   private async _refresh(pattern: RegExp): Promise<void> {
+    if (this._psListInFlight) {
+      this._pendingRefresh = true;
+      return;
+    }
+    this._psListInFlight = true;
     try {
       const allProcesses = await psList();
       const processes = allProcesses.filter((proc: { name: string }) => pattern.test(proc.name));
@@ -83,6 +90,13 @@ export class BuildProcessChecker {
       if (this._timerId) clearInterval(this._timerId);
       this._timerId = undefined;
       this._finishedResolver();
+    } finally {
+      this._psListInFlight = false;
+      if (this._pendingRefresh) {
+        this._pendingRefresh = false;
+        // Immediately retry
+        this._refresh(pattern);
+      }
     }
   }
 }

--- a/src/util/BuildProcessChecker.ts
+++ b/src/util/BuildProcessChecker.ts
@@ -18,13 +18,13 @@ const _defaultPattern =
 
 ///
 
-export class FindProcessChecker implements BuildProcessChecker {
-  constructor(private readonly _log: Logger) {}
+export abstract class BuildProcessCheckerBase {
+  constructor(protected readonly _log: Logger) {}
 
-  private _lastChecked = 0;
+  protected _lastChecked = 0;
   private _finishedP = Promise.resolve();
-  private _finishedResolver = (): void => {};
-  private _timerId: NodeJS.Timeout | undefined = undefined; // number if have running build process
+  protected _finishedResolver = (): void => {};
+  protected _timerId: NodeJS.Timeout | undefined = undefined; // number if have running build process
 
   dispose(): void {
     if (this._timerId) clearInterval(this._timerId);
@@ -68,9 +68,15 @@ export class FindProcessChecker implements BuildProcessChecker {
     return this._finishedP;
   }
 
-  private async _refresh(pattern: RegExp): Promise<void> {
+  protected abstract _refresh(pattern: RegExp): Promise<void>;
+}
+
+///
+
+export class FindProcessChecker extends BuildProcessCheckerBase {
+  protected override async _refresh(pattern: RegExp): Promise<void> {
     try {
-      // wrong type definition for find habdles RegExp: https://github.com/yibn2008/find-process/compare/1.4.11...2.0.0#diff-81b33228621820bded04ffbd7d49375fc742662fde6b7111ddb10457ceef7ae9R11
+      // wrong type definition for find handles RegExp: https://github.com/yibn2008/find-process/compare/1.4.11...2.0.0#diff-81b33228621820bded04ffbd7d49375fc742662fde6b7111ddb10457ceef7ae9R11
       const processes = await find('name', pattern as unknown as string);
 
       this._lastChecked = Date.now();
@@ -80,7 +86,7 @@ export class FindProcessChecker implements BuildProcessChecker {
           'Found running build related processes: ' + processes.map(x => JSON.stringify(x, undefined, 0)).join(', '),
         );
       } else {
-        this._log.info('Not found running build related process');
+        this._log.debug('Not found running build related process');
         this._finishedResolver();
         clearInterval(this._timerId!);
         this._timerId = undefined;
@@ -96,85 +102,30 @@ export class FindProcessChecker implements BuildProcessChecker {
 
 ///
 
-// export class PSListProcessChecker implements BuildProcessChecker {
-//   constructor(private readonly _log: Logger) {}
+export class PSListProcessChecker extends BuildProcessCheckerBase {
+  protected override async _refresh(pattern: RegExp): Promise<void> {
+    try {
+      const processes = await psList({ all: false });
 
-//   private readonly _checkIntervalMillis = 2000;
-//   // https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers
-//   private readonly _defaultPattern =
-//     /(^|[/\\])(bazel|cmake|make|ninja|cl|c\+\+|ld|clang|clang\+\+|gcc|g\+\+|link|icc|armcc|armclang)(-[^/\\]+)?(\.exe)?$/;
-//   private _lastChecked = 0;
-//   private _finishedP = Promise.resolve();
-//   private _finishedResolver = (): void => {};
-//   private _timerId: NodeJS.Timeout | undefined = undefined;
-//   private _psListInFlight = false;
-//   private _pendingRefresh = false;
+      this._lastChecked = Date.now();
 
-//   dispose(): void {
-//     if (this._timerId) clearInterval(this._timerId);
-//     this._finishedResolver();
-//   }
+      const found = processes.find(v => {
+        return v.name.match(pattern);
+      });
 
-//   resolveAtFinish(pattern: string | boolean | undefined): Promise<void> {
-//     if (pattern === false) return Promise.resolve();
-
-//     if (this._timerId !== undefined) {
-//       return this._finishedP;
-//     }
-
-//     const elapsed = Date.now() - this._lastChecked;
-
-//     if (elapsed < 300) {
-//       return Promise.resolve();
-//     }
-
-//     this._finishedP = new Promise(r => {
-//       this._finishedResolver = r;
-//     });
-
-//     const patternToUse = typeof pattern == 'string' ? RegExp(pattern) : this._defaultPattern;
-//     this._log.info('Checking running build related processes', patternToUse);
-//     this._timerId = setInterval(() => this._refresh(patternToUse), this._checkIntervalMillis);
-//     this._refresh(patternToUse);
-
-//     return this._finishedP;
-//   }
-
-//   private async _refresh(pattern: RegExp): Promise<void> {
-//     if (this._psListInFlight) {
-//       this._pendingRefresh = true;
-//       return;
-//     }
-//     this._psListInFlight = true;
-//     try {
-//       const allProcesses = await psList();
-//       const processes = allProcesses.filter((proc: { name: string }) => pattern.test(proc.name));
-
-//       this._lastChecked = Date.now();
-
-//       if (processes.length > 0) {
-//         this._log.info(
-//           'Found running build related processes: ' +
-//             processes.map((x: { name: string }) => JSON.stringify(x, undefined, 0)).join(', '),
-//         );
-//       } else {
-//         this._log.info('Not found running build related process');
-//         this._finishedResolver();
-//         if (this._timerId) clearInterval(this._timerId);
-//         this._timerId = undefined;
-//       }
-//     } catch (reason) {
-//       this._log.exceptionS(reason);
-//       if (this._timerId) clearInterval(this._timerId);
-//       this._timerId = undefined;
-//       this._finishedResolver();
-//     } finally {
-//       this._psListInFlight = false;
-//       if (this._pendingRefresh) {
-//         this._pendingRefresh = false;
-//         // Immediately retry
-//         this._refresh(pattern);
-//       }
-//     }
-//   }
-// }
+      if (found !== undefined) {
+        this._log.info('Found running at least 1 build related process: ' + (found.path ?? found.name));
+      } else {
+        this._log.debug('Not found running build related process');
+        this._finishedResolver();
+        clearInterval(this._timerId!);
+        this._timerId = undefined;
+      }
+    } catch (reason) {
+      this._log.exceptionS(reason);
+      clearInterval(this._timerId!);
+      this._timerId = undefined;
+      this._finishedResolver();
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces `find-process` with `ps-list` and a regex match.  
All find-process is being used for is to check if a process which matches the given regex is running. We don't need any of the detailed information provided by it, like the PID, etc.

On Windows at least, this uses a bundled copy of [fastlist](https://github.com/MarkTiedemann/fastlist), which seems to be a lot more efficient.

It also adds a flag to the `_refresh` function to prevent multiple runs occurring at once. It may have too many flags. It solved the issue on my machine, anyway.

**Which issue(s) this PR fixes**:

[#488 waitForBuildProcess spawning multiple heavyweight Powershell instances on Windows.](https://github.com/matepek/vscode-catch2-test-adapter/issues/488)
