### PR TITLE
Use vscode-variables to expand variables in executable patterns and excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- support for variable substituion in "pattern" and "exclude" options
+
 ## [4.19.0] - 2025-10-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-catch2-test-adapter",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-catch2-test-adapter",
-      "version": "4.18.0",
+      "version": "4.19.0",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -44,6 +44,7 @@
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.29.0",
+        "vscode-variables": "1.0.1",
         "webpack": "^5.98.0",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^6.0.1"
@@ -861,6 +862,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1559,6 +1561,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1618,6 +1621,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1920,6 +1924,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2980,6 +2985,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7198,6 +7204,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7480,6 +7487,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7646,6 +7654,13 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/vscode-variables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-variables/-/vscode-variables-1.0.1.tgz",
+      "integrity": "sha512-iZ1d08I30ktqv4mMszGz2Y2o53r+PBpF5tEnwf8NNzKoxeuo0thoaFRG98uJkNVhOtiDmH4HJ3KlqfjM6XIxbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -7666,6 +7681,7 @@
       "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7853,6 +7869,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.29.0",
+    "vscode-variables":"1.0.1",
     "webpack": "^5.98.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1"

--- a/src/@types/vscode-variables/index.d.ts
+++ b/src/@types/vscode-variables/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'vscode-variables' {
+  function vscodeVariables(str: string, recursive?: boolean): string;
+  export = vscodeVariables;
+}

--- a/src/Configurations.ts
+++ b/src/Configurations.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import vscodeVariables from 'vscode-variables';
 import { Logger } from './Logger';
 import { ConfigOfExecGroup } from './ConfigOfExecGroup';
 import { WorkspaceShared } from './WorkspaceShared';
@@ -464,7 +465,7 @@ export class Configurations {
     const createExecutableConfigFromPattern = (pattern: string): ConfigOfExecGroup => {
       return new ConfigOfExecGroup(
         shared,
-        pattern,
+        vscodeVariables(pattern),
         undefined,
         undefined,
         undefined,
@@ -547,14 +548,14 @@ export class Configurations {
 
         let pattern = '';
         {
-          if (typeof obj.pattern == 'string') pattern = obj.pattern;
+          if (typeof obj.pattern == 'string') pattern = vscodeVariables(obj.pattern);
           else {
             this._log.warn('pattern property is required', obj);
             throw Error('"pattern" property is required in advancedExecutables.');
           }
         }
 
-        const exclude: string | null | undefined = obj.exclude;
+        const exclude: string | undefined = typeof obj.exclude === 'string' ? vscodeVariables(obj.exclude) : undefined;
 
         const cwd: string = typeof obj.cwd === 'string' ? obj.cwd : defaultCwd;
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!  Here are some tips for you:
  Please read: https://github.com/matepek/vscode-catch2-test-adapter/blob/master/CONTRIBUTING.md

  Checklist:
  - Are the tests are running? (`npm test`)
  - Is the `CHANGELOG.md` was updated?
-->

**What this PR does / why we need it**:

When you have a build tree which keeps multiple configurations (debug/release) side-by-side, they can be captured by the same pattern and cause duplication in the test list. Adding support for variable substituion in the pattern makes it easier to restrict the search to only the necessary directory.

This also helps support multi-folder workspaces where for a large project you may only want to add a few folders to your workspace, but still use the project build system which would have a root outside of the vscode workspace.

